### PR TITLE
11 fix path to be array

### DIFF
--- a/src/asyncValidation.js
+++ b/src/asyncValidation.js
@@ -11,7 +11,7 @@ const callValidator = (validator, values, path, options, errors) => {
       }
 
       errors.details.push({
-        path: path,
+        path: [path],
         message: err.message,
         type: err.type,
         data: err.data,
@@ -55,14 +55,11 @@ const asyncValidation = (joiSchema, customSchema) => {
       return Promise.all(promises)
         .then(() => {
           if (errors.details.length) {
-            return errors;
+            throw errors;
           } else {
             return values;
           }
         })
-        .catch((err) => {
-          return err;
-        });
     });
   };
 


### PR DESCRIPTION
This fixes the path to be an array. 
Changes the returning errors to a throw. 

Updates tests accordingly. 

Related to:
Hapi expects error details to have path as an array, they are currently strings #11